### PR TITLE
Refine Recycle I/O

### DIFF
--- a/PhotoSift/FileManagement.cs
+++ b/PhotoSift/FileManagement.cs
@@ -23,7 +23,7 @@ using System.Text;
 using System.Windows.Forms;
 using System.Threading;
 using System.IO;
-
+using Microsoft.VisualBasic.FileIO;
 
 namespace PhotoSift
 {
@@ -226,7 +226,7 @@ namespace PhotoSift
 					if( sendToRecycleBin )
 					{
 						Console.WriteLine( "[RECYCLE] " + filePath );
-						winApi.Recycle( filePath );
+						MoveToRecycle( filePath );
 						AddToUndo( filePath, "", UndoMode.Delete, picIndex );
 					}
 					else
@@ -241,14 +241,18 @@ namespace PhotoSift
 				}
 			} ).Start();	// start thread
 		}
-		private void Undelete( string fileName )
+		private void Undelete(string filePath)
 		{
-			if( !winApi.Restore( fileName ) )
+			if( !winApi.Restore(filePath) )
 			{
-				MessageBox.Show( "Could not restore " + fileName + "...", "Undelete Error", MessageBoxButtons.OK, MessageBoxIcon.Error );
+				MessageBox.Show( "Could not restore " + filePath + "...", "Undelete Error", MessageBoxButtons.OK, MessageBoxIcon.Error );
 			}
 			
 		}
 
+		private void MoveToRecycle(string filePath)
+		{
+			FileSystem.DeleteFile(filePath, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
+		}
 	}
 }

--- a/PhotoSift/PhotoSift.csproj
+++ b/PhotoSift/PhotoSift.csproj
@@ -53,6 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/PhotoSift/WinApi.cs
+++ b/PhotoSift/WinApi.cs
@@ -241,7 +241,7 @@ namespace PhotoSift
 					string FilePath = Recycler.GetDetailsOf( FI, 1 );
 					if( Item == Path.Combine( FilePath, FileName ) )
 					{
-						DoVerb( FI, "ESTORE" );
+						DoVerb( FI, "&E" ); // "R&estore", "还原(&E)", etc.
 						success = true;
 						break;
 					}

--- a/PhotoSift/frmMain.cs
+++ b/PhotoSift/frmMain.cs
@@ -341,6 +341,7 @@ namespace PhotoSift
 			try
 			{
 				picCurrent.Image = imageCache.GetImage( pics[iCurrentPic] );
+				if (picCurrent.Image == null) throw new Exception("Loading image fail: " + pics[iCurrentPic]);
 
 				CurrentAspectRatio = (float)picCurrent.Image.Size.Height / picCurrent.Image.Size.Width;
 


### PR DESCRIPTION
use VisualBasic.FileIO, fix the window title bar blink while deleting.
Partial repair Restore from Recycle not work in Non-English locale OS, e.g. zh-CN.
Note: I haven't tested it on English Windows, please confirm it works.