### PR TITLE
Target folder to Settings & save as relative path

### DIFF
--- a/PhotoSift/AppSettings.cs
+++ b/PhotoSift/AppSettings.cs
@@ -52,9 +52,17 @@ namespace PhotoSift
 		public DeleteOptions DeleteMode { get; set; }
 		[Category(" File Operations"), DisplayName("Target Folder"), DescriptionAttribute("Move to the target folder.")]
 		[EditorAttribute(typeof(FolderNameEditor), typeof(UITypeEditor))]
-		public string TargetFolder { get; set; }
+		public string TargetFolderPath { get; set; }
+		[System.Xml.Serialization.XmlIgnore]
+		[Browsable(false)]
+		public string TargetFolder
+		{
+			get => this.TargetFolderPath.Replace("%PhotoSift%",
+					System.Windows.Forms.Application.StartupPath);
+			set => this.TargetFolderPath = SaveRelativePaths ? value.Replace(System.Windows.Forms.Application.StartupPath,
+						   "%PhotoSift%") : value;
+		}
 
-	
 		// Appearance Group
 #if RLVISION
 		[Category( "Appearance" ), DisplayName( "Background color" ), DescriptionAttribute( "Sets the window background color." )]
@@ -320,6 +328,11 @@ namespace PhotoSift
 		public string KeyFolder_9 { get; set; }
 
 
+		// Misc settings
+		[Category("Controls"), DisplayName("Save relative paths"), DescriptionAttribute("Save the path relative to the location of the program, for paths such as the target folder.")]
+		public bool SaveRelativePaths { get; set; }
+
+
 		// Settings located on the GUI menus (not visible in the property grid)
 		[Browsable( false )]
 		public bool AddInRandomOrder { get; set; }
@@ -415,6 +428,9 @@ namespace PhotoSift
 #endif
 			// System Group
 			PreventSleep = false;
+
+			// Misc
+			SaveRelativePaths = true;
 
 			// GUI settings
 			TargetFolder = System.IO.Path.GetDirectoryName( System.Windows.Forms.Application.ExecutablePath );

--- a/PhotoSift/AppSettings.cs
+++ b/PhotoSift/AppSettings.cs
@@ -50,6 +50,9 @@ namespace PhotoSift
 		[Category( " File Operations" ), DisplayName( "Delete mode" ), DescriptionAttribute( "Determines the action to take when pressing the delete key. You can force different modes with Shift+Del (Delete), Alt+Del (Recycle) and Ctrl+Del (Remove from List)" )]
 		[TypeConverter( typeof( EnumTypeConverter ) )]
 		public DeleteOptions DeleteMode { get; set; }
+		[Category(" File Operations"), DisplayName("Target Folder"), DescriptionAttribute("Move to the target folder.")]
+		[EditorAttribute(typeof(FolderNameEditor), typeof(UITypeEditor))]
+		public string TargetFolder { get; set; }
 
 	
 		// Appearance Group
@@ -320,8 +323,6 @@ namespace PhotoSift
 		// Settings located on the GUI menus (not visible in the property grid)
 		[Browsable( false )]
 		public bool AddInRandomOrder { get; set; }
-		[Browsable( false )]
-		public string TargetFolder { get; set; }
 		[Browsable( false )]
 		public bool ResetViewModeOnPictureChange { get; set; }
 


### PR DESCRIPTION
This may not be good practice for using get/set functions.

It exposes the item to settings, allow users to confirm it instead of doubting and relocate.
At the same time, I confirmed the user can enter it directly, and the program automatically creating missing folders, which is a new feature.

#2: `I think F9 and F12 don't support properly Relative Paths yet (%PhotoSift%....).`
p.s. F9 is Set Target Base Folder, F12 is Settings.
pp.s. I think Settings - Key is relative already.

`DescriptionAttribute("Move to the target folder.")]` is not perfect, change it if you like.