### PR TITLE
Avoid Escape key spreading too far

### DIFF
--- a/PhotoSift/frmMain.cs
+++ b/PhotoSift/frmMain.cs
@@ -49,6 +49,7 @@ namespace PhotoSift
 		private Rectangle NormalWindowStateFormRect;
 
 		private bool bMenuInUse = false;
+		private bool bEscIsPassed = false;
 
 		private bool bCursorVisible = true;
 		private int FullScreenCursorLastMouseX = -1;

--- a/PhotoSift/frmMain_Input.cs
+++ b/PhotoSift/frmMain_Input.cs
@@ -508,8 +508,9 @@ namespace PhotoSift
 
 
 			// Process all other keys
-			if( e.KeyCode == Keys.Escape )		// exit
+			if( e.KeyCode == Keys.Escape && bEscIsPassed)		// exit
 			{
+				bEscIsPassed = false;
 				if( bFullScreen )
 					ToggleFullscreen();
 				else if( settings.CloseOnEscape )
@@ -712,6 +713,10 @@ namespace PhotoSift
 			{
 				SetScaleMode( ScaleMode.NormalFitWindow );
 				e.Handled = true;
+			}
+			else if (e.KeyCode == Keys.Escape)
+			{
+				bEscIsPassed = true;
 			}
 		}
 


### PR DESCRIPTION
Fix #1. This is a major experience fixes, partial bug cases:
* Open the Settings, press Esc key: the Settings window closed and the program is exiting, if `settings.CloseOnEscape` be true.
* Press F11 to full screen, press Tab key to show the menu bar, open the Settings, press Esc key: the Settings window closes and full screen is leave.
* more see #1...